### PR TITLE
Fix Ruby 2.7 deprecation warning on Key#filter method

### DIFF
--- a/lib/dry/schema/macros/key.rb
+++ b/lib/dry/schema/macros/key.rb
@@ -26,8 +26,8 @@ module Dry
         # @return [Macros::Key]
         #
         # @api public
-        def filter(*args, &block)
-          (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(*args, &block)
+        def filter(*args, **opts, &block)
+          (filter_schema_dsl[name] || filter_schema_dsl.optional(name)).value(*args, **opts, &block)
           self
         end
         ruby2_keywords(:filter) if respond_to?(:ruby2_keywords, true)


### PR DESCRIPTION
Fixes deprecation warning on Key#filter method:

/dry-schema-1.5.5/lib/dry/schema/macros/key.rb:30: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/dry-schema-1.5.5/lib/dry/schema/macros/key.rb:56: warning: The called method `value' is defined here